### PR TITLE
Raise on degenerate chunk partitions instead of failing silently

### DIFF
--- a/lib/diffc/rcc/chunk_coding.py
+++ b/lib/diffc/rcc/chunk_coding.py
@@ -13,6 +13,17 @@ def partition_mu(dim, chunk_sizes, shared_seed=0):
         chunk_ndims.append(int(dim * chunk_size / total_bits))
     chunk_ndims.append(dim - sum(chunk_ndims))
 
+    # An empty chunk would still encode a seed (pure bitstream waste) while
+    # its dimensions pile into the last chunk, far exceeding what that
+    # chunk's 2^chunk_size candidates can represent.
+    if min(chunk_ndims) < 1:
+        raise ValueError(
+            f"Cannot partition {dim} dimensions into {len(chunk_sizes)} "
+            f"chunks: at least one chunk would receive zero dimensions. "
+            f"The step's Dkl is too large for the latent dimension at "
+            f"this max_chunk_size."
+        )
+
     partition_indices = np.concatenate(
         [np.full(ndims, i) for i, ndims in enumerate(chunk_ndims)]
     )


### PR DESCRIPTION
`partition_mu` gives chunk *i* `int(dim * chunk_size_i / total_bits)` dimensions, with the last chunk taking the remainder. When a step's `Dkl` approaches or exceeds `dim * (max_chunk_size - chunk_padding)` bits, some chunks round down to **zero dimensions**—in the extreme (`num_chunks > dim`), every dimension lands in the last chunk, which then codes the entire step's `Dkl` with only `2^max_chunk_size` candidates, while the empty chunks still spend bits encoding seeds that carry no information. Nothing errors, so it surfaces only as quietly poor rate–distortion. Example at `max_chunk_size: 16`, `dim` = 16384 (SD 512×512): `Dkl` = 327680 → 23,406 chunks, 23,405 of them empty, all dims in one chunk.

In this regime the requested rate genuinely exceeds what the scheme can carry, so any silent handling would have to pick a policy for what to drop. This PR therefore raises an explicit error instead: a `ValueError` in `partition_mu` (both encode and decode pass through it) stating the cause.

Not reachable with the shipped configs: sweeping every value in the commented `manual_dkl_per_step` profiles of all five configs, the guard never fires and partitions are unchanged. Thanks for the reference implementation!
