### PR TITLE
Fix int32 overflow in reverse_channel_encode_kernel's curand offset

### DIFF
--- a/lib/diffc/rcc/cuda_kernels.cu
+++ b/lib/diffc/rcc/cuda_kernels.cu
@@ -30,8 +30,13 @@ __global__ void reverse_channel_encode_kernel(
     if (idx >= K) return;
 
     curandState state;
-    curand_init(shared_seed, 0, idx * dim, &state);
-    
+    // Cast before multiplying: idx * dim is an int32 product, which wraps when
+    // idx * dim >= 2^31 (e.g. the upper candidates of a single 2^16-candidate
+    // chunk over >= 32768 dims). generate_sample_kernel computes the same
+    // offset in 64 bits, so the sample scored here would silently differ from
+    // the sample regenerated for the winning index.
+    curand_init(shared_seed, 0, ((unsigned long long)idx) * dim, &state);
+
     //curand_init(shared_seed + idx, 0, 0, &state);
     
     float log_w_value = 0.0f;


### PR DESCRIPTION
In `reverse_channel_encode_kernel`, the curand offset `idx * dim` is an `int × int` product, which wraps at 2³¹. `generate_sample_kernel` declares `idx` as `unsigned long long`, so it computes the same offset correctly in 64 bits. Past the wrap point the encoder scores candidates drawn at wrapped offsets, while the winning sample is regenerated (at both encode and decode time) at the correct offset—so the transmitted sample is not the one whose importance weight won the race, silently degrading the coded sample. This PR casts before multiplying, matching `generate_sample_kernel`.

It triggers when `chunk_dim * 2^chunk_bits ≥ 2³¹`: with `max_chunk_size: 16`, a chunk holding ≥ 32,768 dimensions—e.g. a low-`Dkl` (one- or two-chunk) step on SDXL's 65,536-dim latent. SD at 512×512 peaks at 2³⁰, so default-resolution configs are unaffected. Behaviour is bit-identical wherever the old product didn't wrap.

<details>
<summary>Repro (any CUDA GPU, from repo root)</summary>

```python
import cupy as cp
import numpy as np

mod = cp.RawModule(code=open("lib/diffc/rcc/cuda_kernels.cu").read())
encode_k = mod.get_function("reverse_channel_encode_kernel")
gen_k = mod.get_function("generate_sample_kernel")

dim = K = 65536  # SDXL 1024x1024 latent; 2^16 candidates
seed = 1234
mu = cp.asarray(np.random.default_rng(0).standard_normal(dim), dtype=cp.float32)
log_w = cp.empty(K, dtype=cp.float32)
encode_k(((K + 255) // 256, 1, 1), (256, 1, 1),
         (mu, cp.int32(dim), cp.uint64(K), cp.uint64(seed), log_w))

for idx in [0, 32767, 32768, 65535]:  # idx*dim crosses 2^31 at 32768
    out = cp.empty(dim, dtype=cp.float32)
    gen_k((1, 1, 1), (1, 1, 1), (cp.int32(dim), cp.uint64(seed), cp.uint64(idx), out))
    print(idx, np.isclose(float(log_w[idx]), float(out @ mu), rtol=1e-3))
```

Before the fix, indices ≥ 32768 are scored from a different sample than the one regenerated for them; after the fix all match.

</details>

Thanks for the reference implementation!
